### PR TITLE
Port rejseplan

### DIFF
--- a/example_rejseplanen.py
+++ b/example_rejseplanen.py
@@ -1,0 +1,44 @@
+import datetime
+
+from pyhafas import HafasClient
+from pyhafas.profile import RKRPProfile
+
+client = HafasClient(RKRPProfile(), debug=True)
+
+id_nordhavn='8600653'
+id_kongebakken9='A=2@O=Kongebakken 9, 2765 Smørum, Egedal Kommune@X=12294403@Y=55749256@U=103@L=902400113@B=1@p=1618386996@'
+
+#print(client.departures(
+#    station=id_nordhavn,
+#    date=datetime.datetime.now(),
+#    max_trips=5
+#))
+
+#print(client.arrivals(
+#    station=id_nordhavn,
+#    date=datetime.datetime.now(),
+#    max_trips=5
+#))
+
+# Test searching for an address
+locs = client.locations("Kongebakken 9, 2765 Smørum", rtype='ALL')
+assert(locs[0].lid == id_kongebakken9)
+
+
+possibilities = client.journeys(
+    origin          = id_nordhavn,
+    destination     = id_kongebakken9,
+    date            = datetime.datetime.now(),
+    min_change_time = 0,
+    max_changes     = -1
+)
+
+
+for p in possibilities:
+    print('--------')
+    for l in p.legs:
+        print(l.departure, l.origin.name, "--> " + str(l.name) + " -->" )
+
+    l = p.legs[-1]
+    print(l.arrival, l.destination.name)
+    print("Journey duration: ", p.duration)

--- a/pyhafas/client.py
+++ b/pyhafas/client.py
@@ -175,16 +175,17 @@ class HafasClient:
 
         return self.profile.parse_journey_request(res)
 
-    def locations(self, term: str) -> List[Station]:
+    def locations(self, term: str, rtype: str = 'S') -> List[Station]:
         """
-        Returns stations that are searched with the provided term
+        Returns stations (and addresses) that are searched with the provided term
 
         The further forward the station is in the list, the higher the similarity to the search term.
 
         :param term: Search term
+        :param rtype: Result types. One of ['S' for stations only, 'ALL' for addresses and stations]
         :return: List of FPTF `Station` objects
         """
-        body = self.profile.format_location_request(term)
+        body = self.profile.format_location_request(term, rtype)
         res = self.profile.request(body)
 
         return self.profile.parse_location_request(res)

--- a/pyhafas/profile/__init__.py
+++ b/pyhafas/profile/__init__.py
@@ -2,3 +2,4 @@ from .interfaces import ProfileInterface  # isort:skip
 from .base import BaseProfile
 from .db import DBProfile
 from .vsn import VSNProfile
+from .rkrp import RKRPProfile

--- a/pyhafas/profile/base/helper/parse_leg.py
+++ b/pyhafas/profile/base/helper/parse_leg.py
@@ -47,42 +47,44 @@ class BaseParseLegHelper(ParseLegHelperInterface):
             )
         else:
             leg_stopovers: List[Stopover] = []
-            for stopover in journey['stopL']:
-                leg_stopovers.append(
-                    Stopover(
-                        stop=self.parse_lid_to_station(
-                            common['locL'][stopover['locX']]['lid']
-                        ),
-                        cancelled=bool(
-                            stopover.get(
-                                'dCncl',
+            if 'stopL' in journey:
+                for stopover in journey['stopL']:
+                    leg_stopovers.append(
+                        Stopover(
+                            stop=self.parse_lid_to_station(
+                                common['locL'][stopover['locX']]['lid']
+                            ),
+                            cancelled=bool(
                                 stopover.get(
-                                    'aCncl',
-                                    False
-                                ))),
-                        departure=self.parse_datetime(
-                            stopover.get('dTimeS'),
-                            date) if stopover.get('dTimeS') is not None else None,
-                        departure_delay=self.parse_datetime(
-                            stopover['dTimeR'],
-                            date) - self.parse_datetime(
-                            stopover['dTimeS'],
-                            date) if stopover.get('dTimeR') is not None else None,
-                        departure_platform=stopover.get(
-                            'dPlatfR',
-                            stopover.get('dPlatfS', stopover.get('dPltfR', stopover.get('dPltfS', {})).get('txt'))),
-                        arrival=self.parse_datetime(
-                            stopover['aTimeS'],
-                            date) if stopover.get('aTimeS') is not None else None,
-                        arrival_delay=self.parse_datetime(
-                            stopover['aTimeR'],
-                            date) - self.parse_datetime(
-                            stopover['aTimeS'],
-                            date) if stopover.get('aTimeR') is not None else None,
-                        arrival_platform=stopover.get(
-                            'aPlatfR',
-                            stopover.get('aPlatfS', stopover.get('aPltfR', stopover.get('aPltfS', {})).get('txt'))),
-                    ))
+                                    'dCncl',
+                                    stopover.get(
+                                        'aCncl',
+                                        False
+                                    ))),
+                            departure=self.parse_datetime(
+                                stopover.get('dTimeS'),
+                                date) if stopover.get('dTimeS') is not None else None,
+                            departure_delay=self.parse_datetime(
+                                stopover['dTimeR'],
+                                date) - self.parse_datetime(
+                                stopover['dTimeS'],
+                                date) if stopover.get('dTimeR') is not None else None,
+                            departure_platform=stopover.get(
+                                'dPlatfR',
+                                stopover.get('dPlatfS', stopover.get('dPltfR', stopover.get('dPltfS', {})).get('txt'))),
+                            arrival=self.parse_datetime(
+                                stopover['aTimeS'],
+                                date) if stopover.get('aTimeS') is not None else None,
+                            arrival_delay=self.parse_datetime(
+                                stopover['aTimeR'],
+                                date) - self.parse_datetime(
+                                stopover['aTimeS'],
+                                date) if stopover.get('aTimeR') is not None else None,
+                            arrival_platform=stopover.get(
+                                'aPlatfR',
+                                stopover.get('aPlatfS', stopover.get('aPltfR', stopover.get('aPltfS', {})).get('txt'))),
+                        ))
+
             return Leg(
                 id=journey['jid'],
                 name=common['prodL'][journey['prodX']]['name'],

--- a/pyhafas/profile/base/helper/parse_lid.py
+++ b/pyhafas/profile/base/helper/parse_lid.py
@@ -43,6 +43,7 @@ class BaseParseLidHelper(ParseLidHelperInterface):
 
         return Station(
             id=parsedLid['L'],
+            lid=lid,
             name=name or parsedLid['O'],
             latitude=latitude,
             longitude=longitude

--- a/pyhafas/profile/base/requests/location.py
+++ b/pyhafas/profile/base/requests/location.py
@@ -7,11 +7,12 @@ from pyhafas.types.hafas_response import HafasResponse
 
 
 class BaseLocationRequest(LocationRequestInterface):
-    def format_location_request(self: ProfileInterface, term: str):
+    def format_location_request(self: ProfileInterface, term: str, rtype: str = 'S'):
         """
         Creates the HaFAS request body for a location search request.
 
         :param term: Search term
+        :param type: Result types. One of ['S' for stations, 'ALL' for addresses and stations]
         :return: Request body for HaFAS
         """
         return {
@@ -20,7 +21,7 @@ class BaseLocationRequest(LocationRequestInterface):
                     "field": "S",
                     "loc": {
                         "name": term,
-                        "type": "S"
+                        "type": rtype
                     }
                 }
             },

--- a/pyhafas/profile/interfaces/requests/location.py
+++ b/pyhafas/profile/interfaces/requests/location.py
@@ -7,11 +7,12 @@ from pyhafas.types.hafas_response import HafasResponse
 
 class LocationRequestInterface(abc.ABC):
     @abc.abstractmethod
-    def format_location_request(self, term: str):
+    def format_location_request(self, term: str, rtype: str = 'S'):
         """
         Creates the HaFAS request body for a location search request.
 
         :param term: Search term
+        :param rtype: Result types. One of ['S' for stations, 'ALL' for addresses and stations]
         :return: Request body for HaFAS
         """
         pass

--- a/pyhafas/profile/rkrp/__init__.py
+++ b/pyhafas/profile/rkrp/__init__.py
@@ -1,0 +1,68 @@
+import pytz
+
+from pyhafas.profile.base import BaseProfile
+
+
+class RKRPProfile(BaseProfile):
+    """
+    Profile of the HaFAS of Rejsekort & Rejseplan (RKRP) - Danish {Railway, Bus, Metro, etc.}.
+    https://www.rejsekort.dk/da/RKRP
+    https://help.rejseplanen.dk/hc/da/articles/214174465-Rejseplanens-API
+    """
+
+    # Alternative base URLs (mostly CNAMEs):
+    #     rejseplanen.dk
+    #     webapp.rejseplanen.dk
+    #     www.rejseplanen.dk
+    #     rkrp.hafas.cloud
+    #     rkrp-fat.hafas.cloud
+    baseUrl = "https://www.rejseplanen.dk/bin/iphone.exe"
+    defaultUserAgent = "Dalvik/2.1.0 (Linux; U; Android 11; Pixel 4a Build/RQ2A.210305.006)"
+
+    addMicMac = False
+    addChecksum = False
+
+    locale = 'da-DK'
+    timezone = pytz.timezone('Europe/Copenhagen')
+
+    requestBody = {
+        "client": {
+            "id": "DK",
+            "type": "WEB",
+            "name": "rejseplanwebapp",
+            "l": "vs_webapp"
+        },
+        "ext": "DK.11",
+        "ver": "1.24",
+        "lang": "dan",
+        "auth": {
+            "type": "AID",
+            "aid": "j1sa92pcj72ksh0-web"
+        }
+    }
+
+    availableProducts = {
+        'long_distance_express': [1],  # ICE
+        'long_distance': [2],  # IC/EC
+        'regional_express': [4],  # RE/IR
+        'regional': [8],  # RB
+        'suburban': [16],  # S
+        'bus': [32],  # BUS
+        'ferry': [64],  # F
+        'subway': [128],  # U
+        'tram': [256],  # T
+        'taxi': [512]  # Group Taxi
+    }
+
+    defaultProducts = [
+        'long_distance_express',
+        'long_distance',
+        'regional_express',
+        'regional',
+        'suburban',
+        'bus',
+        'ferry',
+        'subway',
+        'tram',
+        'taxi'
+    ]

--- a/pyhafas/types/fptf.py
+++ b/pyhafas/types/fptf.py
@@ -29,8 +29,10 @@ class Station:
 
     A station is a point where vehicles stop. It may be a larger building or just a small stop without special infrastructure.
 
-    :ivar id: ID of the Station
+    :ivar id: ID of the Station. Typically a number but as a string
     :vartype id: str
+    :ivar lid: Location ID of the Station (maybe `None`). Long-form, containing multiple fields
+    :vartype lid: Optional[str]
     :ivar name: Name of the Station (maybe `None`)
     :vartype name: Optional[str]
     :ivar latitude: Latitude coordinate of the Station (maybe `None`)
@@ -42,6 +44,7 @@ class Station:
     def __init__(
             self,
             id: str,
+            lid: Optional[str] = None,
             name: Optional[str] = None,
             latitude: Optional[float] = None,
             longitude: Optional[float] = None):
@@ -49,11 +52,13 @@ class Station:
         FPTF `Station` object
 
         :param id: Internal ID of the station
+        :param lid: (optional) Internal Location ID of the station. Defaults to None
         :param name: (optional) Name of the station. Defaults to None
         :param latitude: (optional) Latitude coordinate of the station. Defaults to None
         :param longitude: (optional) Longitude coordinate of the station. Defaults to None
         """
         self.id: str = id
+        self.lid: Optional[str] = lid
         self.name: Optional[str] = name
         self.latitude: Optional[float] = latitude
         self.longitude: Optional[float] = longitude

--- a/tests/db/parsing/departures_test.py
+++ b/tests/db/parsing/departures_test.py
@@ -18,6 +18,7 @@ def test_db_departures_parsing():
         direction='Stralsund Hbf',
         station=Station(
             id='8098160',
+            lid='A=1@O=Berlin Hbf (tief)@X=13369549@Y=52525589@U=80@L=8098160@',
             name='Berlin Hbf (tief)',
             latitude=52.525589,
             longitude=13.369549),

--- a/tests/db/parsing/journey_test.py
+++ b/tests/db/parsing/journey_test.py
@@ -20,11 +20,13 @@ def test_db_journey_parsing():
             id='1|227361|0|80|8082020',
             origin=Station(
                 id='8005556',
+                lid='A=1@O=Siegburg/Bonn@X=7203029@Y=50793916@U=80@L=8005556@',
                 name='Siegburg/Bonn',
                 latitude=50.793916,
                 longitude=7.203029),
             destination=Station(
                 id='8000135',
+                lid='A=1@O=Troisdorf@X=7150892@Y=50813926@U=80@L=8000135@',
                 name='Troisdorf',
                 latitude=50.813926,
                 longitude=7.150892),
@@ -40,6 +42,7 @@ def test_db_journey_parsing():
             stopovers=[Stopover(
                 stop=Station(
                     id='8005556',
+                    lid='A=1@O=Siegburg/Bonn@X=7203029@Y=50793916@U=80@L=8005556@',
                     name='Siegburg/Bonn',
                     latitude=50.793916,
                     longitude=7.203029
@@ -54,6 +57,7 @@ def test_db_journey_parsing():
             ), Stopover(
                 stop=Station(
                     id='8000135',
+                    lid='A=1@O=Troisdorf@X=7150892@Y=50813926@U=80@L=8000135@',
                     name='Troisdorf',
                     latitude=50.813926,
                     longitude=7.150892

--- a/tests/db/parsing/journeys_test.py
+++ b/tests/db/parsing/journeys_test.py
@@ -20,11 +20,13 @@ def test_db_journeys_parsing():
             id='1|226393|0|80|6082020',
             origin=Station(
                 id='8005556',
+                lid='A=1@O=Siegburg/Bonn@X=7203029@Y=50793916@U=80@L=8005556@',
                 name='Siegburg/Bonn',
                 latitude=50.793916,
                 longitude=7.203029),
             destination=Station(
                 id='8000135',
+                lid='A=1@O=Troisdorf@X=7150892@Y=50813926@U=80@L=8000135@',
                 name='Troisdorf',
                 latitude=50.813926,
                 longitude=7.150892),
@@ -41,6 +43,7 @@ def test_db_journeys_parsing():
             stopovers=[Stopover(
                 stop=Station(
                     id='8005556',
+                    lid='A=1@O=Siegburg/Bonn@X=7203029@Y=50793916@U=80@L=8005556@',
                     name='Siegburg/Bonn',
                     latitude=50.793916,
                     longitude=7.203029),
@@ -54,6 +57,7 @@ def test_db_journeys_parsing():
                 Stopover(
                     stop=Station(
                         id='8000135',
+                        lid='A=1@O=Troisdorf@X=7150892@Y=50813926@U=80@L=8000135@',
                         name='Troisdorf',
                         latitude=50.813926,
                         longitude=7.150892),

--- a/tests/db/parsing/locations_test.py
+++ b/tests/db/parsing/locations_test.py
@@ -14,11 +14,13 @@ def test_db_locations_parsing():
     correct_locations = [
         Station(
             id='008000207',
+            lid='A=1@O=Köln Hbf@X=6958730@Y=50943029@U=80@L=008000207@B=1@p=1596188796@',
             name='Köln Hbf',
             latitude=50.942823,
             longitude=6.959197
         ), Station(
             id="008096022",
+            lid='A=1@O=KÖLN@X=6967206@Y=50941312@U=80@L=008096022@B=1@p=1596188796@',
             name='KÖLN',
             latitude=50.941312,
             longitude=6.967206)

--- a/tests/db/parsing/trip_test.py
+++ b/tests/db/parsing/trip_test.py
@@ -16,11 +16,13 @@ def test_db_trips_parsing():
         id='1|227083|0|80|5082020',
         origin=Station(
             id='8002753',
+            lid='A=1@O=Hennef(Sieg)@X=7284588@Y=50773331@U=80@L=8002753@',
             name='Hennef(Sieg)',
             latitude=50.773331,
             longitude=7.284588),
         destination=Station(
             id='8000084',
+            lid='A=1@O=Düren@X=6482454@Y=50809513@U=80@L=8000084@',
             name='Düren',
             latitude=50.809513,
             longitude=6.482454
@@ -39,6 +41,7 @@ def test_db_trips_parsing():
             Stopover(
                 stop=Station(
                     id='8002753',
+                    lid='A=1@O=Hennef(Sieg)@X=7284588@Y=50773331@U=80@L=8002753@',
                     name='Hennef(Sieg)',
                     latitude=50.773331,
                     longitude=7.284588
@@ -53,6 +56,7 @@ def test_db_trips_parsing():
             ), Stopover(
                 stop=Station(
                     id='8005556',
+                    lid='A=1@O=Siegburg/Bonn@X=7203029@Y=50793916@U=80@L=8005556@',
                     name='Siegburg/Bonn',
                     latitude=50.793916,
                     longitude=7.203029
@@ -67,6 +71,7 @@ def test_db_trips_parsing():
             ), Stopover(
                 stop=Station(
                     id='8000135',
+                    lid='A=1@O=Troisdorf@X=7150892@Y=50813926@U=80@L=8000135@',
                     name='Troisdorf',
                     latitude=50.813926,
                     longitude=7.150892
@@ -81,6 +86,7 @@ def test_db_trips_parsing():
             ), Stopover(
                 stop=Station(
                     id='8005629',
+                    lid='A=1@O=Spich@X=7114917@Y=50826727@U=80@L=8005629@',
                     name='Spich',
                     latitude=50.826727,
                     longitude=7.114917
@@ -95,6 +101,7 @@ def test_db_trips_parsing():
             ), Stopover(
                 stop=Station(
                     id='8004873',
+                    lid='A=1@O=Porz-Wahn@X=7079266@Y=50858135@U=80@L=8004873@',
                     name='Porz-Wahn',
                     latitude=50.858135,
                     longitude=7.079266
@@ -109,6 +116,7 @@ def test_db_trips_parsing():
             ), Stopover(
                 stop=Station(
                     id='8003330',
+                    lid='A=1@O=Köln/Bonn Flughafen@X=7119304@Y=50878900@U=80@L=8003330@',
                     name='Köln/Bonn Flughafen',
                     latitude=50.8789,
                     longitude=7.119304
@@ -123,6 +131,7 @@ def test_db_trips_parsing():
             ), Stopover(
                 stop=Station(
                     id='8003358',
+                    lid='A=1@O=Köln Frankfurter Straße@X=7051264@Y=50915217@U=80@L=8003358@',
                     name='Köln Frankfurter Straße',
                     latitude=50.915217,
                     longitude=7.051264
@@ -137,6 +146,7 @@ def test_db_trips_parsing():
             ), Stopover(
                 stop=Station(
                     id='8003320',
+                    lid='A=1@O=Köln Trimbornstr@X=6996736@Y=50935856@U=80@L=8003320@',
                     name='Köln Trimbornstr',
                     latitude=50.935856,
                     longitude=6.996736),
@@ -150,6 +160,7 @@ def test_db_trips_parsing():
             ), Stopover(
                 stop=Station(
                     id='8083368',
+                    lid='A=1@O=Köln Messe/Deutz Gl. 9-10@X=6974640@Y=50941303@U=80@L=8083368@',
                     name='Köln Messe/Deutz Gl. 9-10',
                     latitude=50.941303,
                     longitude=6.97464),
@@ -163,6 +174,7 @@ def test_db_trips_parsing():
             ), Stopover(
                 stop=Station(
                     id='8000207',
+                    lid='A=1@O=Köln Hbf@X=6958730@Y=50943029@U=80@L=8000207@',
                     name='Köln Hbf',
                     latitude=50.943029,
                     longitude=6.95873
@@ -177,6 +189,7 @@ def test_db_trips_parsing():
             ), Stopover(
                 stop=Station(
                     id='8003392',
+                    lid='A=1@O=Köln Hansaring@X=6952563@Y=50949133@U=80@L=8003392@',
                     name='Köln Hansaring',
                     latitude=50.949133,
                     longitude=6.952563
@@ -191,6 +204,7 @@ def test_db_trips_parsing():
             ), Stopover(
                 stop=Station(
                     id='8000208',
+                    lid='A=1@O=Köln-Ehrenfeld@X=6917280@Y=50951533@U=80@L=8000208@',
                     name='Köln-Ehrenfeld',
                     latitude=50.951533,
                     longitude=6.91728),
@@ -204,6 +218,7 @@ def test_db_trips_parsing():
             ), Stopover(
                 stop=Station(
                     id='8003375',
+                    lid='A=1@O=Köln-Müngersdorf Technologiepark@X=6888200@Y=50948396@U=80@L=8003375@',
                     name='Köln-Müngersdorf Technologiepark',
                     latitude=50.948396,
                     longitude=6.8882
@@ -218,6 +233,7 @@ def test_db_trips_parsing():
             ), Stopover(
                 stop=Station(
                     id='8003732',
+                    lid='A=1@O=Lövenich@X=6834436@Y=50942930@U=80@L=8003732@',
                     name='Lövenich',
                     latitude=50.94293,
                     longitude=6.834436
@@ -232,6 +248,7 @@ def test_db_trips_parsing():
             ), Stopover(
                 stop=Station(
                     id='8003383',
+                    lid='A=1@O=Köln-Weiden West@X=6815136@Y=50940899@U=80@L=8003383@',
                     name='Köln-Weiden West',
                     latitude=50.940899,
                     longitude=6.815136
@@ -246,6 +263,7 @@ def test_db_trips_parsing():
             ), Stopover(
                 stop=Station(
                     id='8002389',
+                    lid='A=1@O=Frechen-Königsdorf@X=6777849@Y=50936503@U=80@L=8002389@',
                     name='Frechen-Königsdorf',
                     latitude=50.936503,
                     longitude=6.777849
@@ -260,6 +278,7 @@ def test_db_trips_parsing():
             ), Stopover(
                 stop=Station(
                     id='8000178',
+                    lid='A=1@O=Horrem@X=6713495@Y=50916250@U=80@L=8000178@',
                     name='Horrem',
                     latitude=50.91625,
                     longitude=6.713495
@@ -274,6 +293,7 @@ def test_db_trips_parsing():
             ), Stopover(
                 stop=Station(
                     id='8005575',
+                    lid='A=1@O=Sindorf@X=6681107@Y=50903711@U=80@L=8005575@',
                     name='Sindorf',
                     latitude=50.903711,
                     longitude=6.681107
@@ -287,6 +307,7 @@ def test_db_trips_parsing():
             ), Stopover(
                 stop=Station(
                     id='8001264',
+                    lid='A=1@O=Buir@X=6574513@Y=50862405@U=80@L=8001264@',
                     name='Buir',
                     latitude=50.862405,
                     longitude=6.574513
@@ -301,6 +322,7 @@ def test_db_trips_parsing():
             ), Stopover(
                 stop=Station(
                     id='8003990',
+                    lid='A=1@O=Merzenich@X=6518051@Y=50840031@U=80@L=8003990@',
                     name='Merzenich',
                     latitude=50.840031,
                     longitude=6.518051
@@ -316,6 +338,7 @@ def test_db_trips_parsing():
             Stopover(
                 stop=Station(
                     id='8000084',
+                    lid='A=1@O=Düren@X=6482454@Y=50809513@U=80@L=8000084@',
                     name='Düren',
                     latitude=50.809513,
                     longitude=6.482454

--- a/tests/vsn/parsing/departures_test.py
+++ b/tests/vsn/parsing/departures_test.py
@@ -18,6 +18,7 @@ def test_vsn_departures_parsing():
         direction='Frankfurt(Main) Hbf',
         station=Station(
             id='8000050',
+            lid='A=1@O=Bremen Hbf@X=8813833@Y=53083478@U=80@L=8000050@',
             name='Bremen Hbf',
             latitude=53.083478,
             longitude=8.813833),

--- a/tests/vsn/parsing/journeys_test.py
+++ b/tests/vsn/parsing/journeys_test.py
@@ -27,12 +27,14 @@ def test_vsn_journeys_parsing():
                     id='1|147532|0|80|9082020',
                     origin=Station(
                         id='8000128',
+                        lid='A=1@O=Göttingen@X=9926069@Y=51536812@U=80@L=8000128@',
                         name='Göttingen',
                         latitude=51.536812,
                         longitude=9.926069
                     ),
                     destination=Station(
                         id='8003644',
+                        lid='A=1@O=Lenglern@X=9871199@Y=51588428@U=80@L=8003644@',
                         name='Lenglern',
                         latitude=51.588428,
                         longitude=9.871199
@@ -63,6 +65,7 @@ def test_vsn_journeys_parsing():
                         Stopover(
                             stop=Station(
                                 id='8000128',
+                                lid='A=1@O=Göttingen@X=9926069@Y=51536812@U=80@L=8000128@',
                                 name='Göttingen',
                                 latitude=51.536812,
                                 longitude=9.926069
@@ -83,6 +86,7 @@ def test_vsn_journeys_parsing():
                         Stopover(
                             stop=Station(
                                 id='8003644',
+                                lid='A=1@O=Lenglern@X=9871199@Y=51588428@U=80@L=8003644@',
                                 name='Lenglern',
                                 latitude=51.588428,
                                 longitude=9.871199


### PR DESCRIPTION
I've ported rejseplanen.dk to pyhafas.

Errata: Busses are labelled wrongly as trains, due to Leg's mode being trains by default.
But other than that, it seems to work.

I've also extended location queries to be more flexible than just Stations: Now one can ask from any address to any other address.

Motivation: I'm doing a digital dashboard with a Raspberry Pi Zero W.
It is not powerful enough to run Chromium(+Puppeteer), so scraping is a no-go.
pyhafas seems nice and extensible, and let's my Pi poll and display the next departures to my workplace :+1: 