### PR TITLE
KVB: Make test use the right Profile

### DIFF
--- a/tests/kvb/request/journeys_test.py
+++ b/tests/kvb/request/journeys_test.py
@@ -1,14 +1,14 @@
 import datetime
 
 from pyhafas import HafasClient
-from pyhafas.profile import VSNProfile
+from pyhafas.profile import KVBProfile
 
 
 def test_vsn_journeys_request():
-    client = HafasClient(VSNProfile())
+    client = HafasClient(KVBProfile())
     journeys = client.journeys(
-        destination="009033817",
-        origin="009054997",
+        destination="900000687",
+        origin="900000008",
         date=datetime.datetime.now(),
         min_change_time=0,
         max_changes=-1


### PR DESCRIPTION
One of the KVB tests used the VSNProfile instead of KVBProfile