### PR TITLE
fix: typo in KVB regionalverkehr id

### DIFF
--- a/pyhafas/profile/kvb/__init__.py
+++ b/pyhafas/profile/kvb/__init__.py
@@ -36,7 +36,7 @@ class KVBProfile(KVBJourneysRequest, KVBJourneyRequest, BaseProfile):
         'stadtbahn': [2],
         'bus': [8],
         'fernverkehr': [32],
-        'regionalverkehr': [46],
+        'regionalverkehr': [64],
         'taxibus': [256]
     }
 

--- a/tests/kvb/request/journeys_test.py
+++ b/tests/kvb/request/journeys_test.py
@@ -4,11 +4,22 @@ from pyhafas import HafasClient
 from pyhafas.profile import KVBProfile
 
 
-def test_vsn_journeys_request():
+def test_kvb_journeys_request():
     client = HafasClient(KVBProfile())
     journeys = client.journeys(
         destination="900000687",
         origin="900000008",
+        date=datetime.datetime.now(),
+        min_change_time=0,
+        max_changes=-1
+    )
+    assert journeys
+
+def test_kvb_journeys_local_request():
+    client = HafasClient(KVBProfile())
+    journeys = client.journeys(
+        destination="900000001",
+        origin="900000039",
         date=datetime.datetime.now(),
         min_change_time=0,
         max_changes=-1


### PR DESCRIPTION
I dug a bit deeper and fixed a typo (reversed digits in the above ID) that seems to have fixed issue #34 .

fixes #34 

In case this gets merged, I would appreciate a minor release so I can proceed with my depending application. :-)