### PR TITLE
Update and fix tests

### DIFF
--- a/tests/db/parsing/departures_test.py
+++ b/tests/db/parsing/departures_test.py
@@ -9,7 +9,7 @@ from tests.types import PyTestHafasResponse
 
 def test_db_departures_parsing():
     directory = os.path.dirname(os.path.realpath(__file__))
-    raw_hafas_json_file = open(directory + "/departures_raw.json", "r")
+    raw_hafas_json_file = open(directory + "/departures_raw.json", "r", encoding="utf8")
     hafas_response = PyTestHafasResponse(raw_hafas_json_file.read())
     raw_hafas_json_file.close()
     correct_station_board_legs = [StationBoardLeg(

--- a/tests/db/parsing/journey_test.py
+++ b/tests/db/parsing/journey_test.py
@@ -9,7 +9,7 @@ from tests.types import PyTestHafasResponse
 
 def test_db_journey_parsing():
     directory = os.path.dirname(os.path.realpath(__file__))
-    raw_hafas_json_file = open(directory + "/journey_raw.json", "r")
+    raw_hafas_json_file = open(directory + "/journey_raw.json", "r", encoding="utf-8")
     hafas_response = PyTestHafasResponse(raw_hafas_json_file.read())
     raw_hafas_json_file.close()
     correct_journey = Journey(

--- a/tests/db/parsing/journeys_test.py
+++ b/tests/db/parsing/journeys_test.py
@@ -9,7 +9,7 @@ from tests.types import PyTestHafasResponse
 
 def test_db_journeys_parsing():
     directory = os.path.dirname(os.path.realpath(__file__))
-    raw_hafas_json_file = open(directory + "/journeys_raw.json", "r")
+    raw_hafas_json_file = open(directory + "/journeys_raw.json", "r", encoding="utf-8")
     hafas_response = PyTestHafasResponse(raw_hafas_json_file.read())
     raw_hafas_json_file.close()
     correct_journeys = [Journey(

--- a/tests/db/parsing/locations_test.py
+++ b/tests/db/parsing/locations_test.py
@@ -8,7 +8,7 @@ from tests.types import PyTestHafasResponse
 
 def test_db_locations_parsing():
     directory = os.path.dirname(os.path.realpath(__file__))
-    raw_hafas_json_file = open(directory + "/locations_raw.json", "r")
+    raw_hafas_json_file = open(directory + "/locations_raw.json", "r", encoding="utf-8")
     hafas_response = PyTestHafasResponse(raw_hafas_json_file.read())
     raw_hafas_json_file.close()
     correct_locations = [

--- a/tests/db/parsing/trip_test.py
+++ b/tests/db/parsing/trip_test.py
@@ -9,7 +9,7 @@ from tests.types import PyTestHafasResponse
 
 def test_db_trips_parsing():
     directory = os.path.dirname(os.path.realpath(__file__))
-    raw_hafas_json_file = open(directory + "/trip_raw.json", "r")
+    raw_hafas_json_file = open(directory + "/trip_raw.json", "r", encoding="utf-8")
     hafas_response = PyTestHafasResponse(raw_hafas_json_file.read())
     raw_hafas_json_file.close()
     correct_trip = Leg(

--- a/tests/db/request/journey_test.py
+++ b/tests/db/request/journey_test.py
@@ -6,8 +6,12 @@ from pyhafas.types.fptf import Journey
 
 
 def test_db_journey_request():
-    client = HafasClient(DBProfile())
+    profile = DBProfile()
+    today = datetime.datetime.now(datetime.UTC)
+    start = profile.transform_datetime_parameter_timezone(today).strftime('%Y%m%d1439')
+    end = profile.transform_datetime_parameter_timezone(today).strftime('%Y%m%d1445')
+    client = HafasClient(profile)
     journey = client.journey(
-        journey="¶HKI¶T$A=1@O=Siegburg/Bonn@L=8005556@a=128@$A=1@O=Hennef(Sieg)@L=8002753@a=128@$202306101439$202306101445$S     12$$1$$$",
+        journey=f"¶HKI¶T$A=1@O=Siegburg/Bonn@L=8005556@a=128@$A=1@O=Hennef(Sieg)@L=8002753@a=128@${start}${end}$S     12$$1$$$",
     )
     assert isinstance(journey, Journey)

--- a/tests/kvb/parsing/departures_test.py
+++ b/tests/kvb/parsing/departures_test.py
@@ -1,4 +1,5 @@
 import datetime
+import locale
 import os
 
 from pyhafas.profile.kvb import KVBProfile
@@ -9,9 +10,10 @@ from tests.types import PyTestHafasResponse
 
 def test_kvb_departures_parsing():
     directory = os.path.dirname(os.path.realpath(__file__))
-    raw_hafas_json_file = open(directory + "/departures_raw.json", "r")
+    raw_hafas_json_file = open(directory + "/departures_raw.json", "r", encoding="utf8")
     hafas_response = PyTestHafasResponse(raw_hafas_json_file.read())
     raw_hafas_json_file.close()
+    encoding = locale.getencoding()
     correct_station_board_legs = [StationBoardLeg(
         id='1|119823|0|1|24052023',
         name='609',

--- a/tests/kvb/request/journey_test.py
+++ b/tests/kvb/request/journey_test.py
@@ -1,3 +1,5 @@
+import datetime
+
 from pyhafas import HafasClient
 from pyhafas.profile import KVBProfile
 from pyhafas.types.fptf import Journey

--- a/tests/nasa/requests/journey_test.py
+++ b/tests/nasa/requests/journey_test.py
@@ -1,3 +1,5 @@
+import datetime
+
 from pyhafas import HafasClient
 from pyhafas.profile import NASAProfile
 from pyhafas.types.fptf import Journey
@@ -5,8 +7,12 @@ from pyhafas.types.fptf import Journey
 
 # Test journey request with NASA profile
 def test_nasa_journey_request():
-    client = HafasClient(NASAProfile())
+    profile = NASAProfile()
+    today = datetime.datetime.now(datetime.UTC)
+    start = profile.transform_datetime_parameter_timezone(today).strftime('%Y%m%d2115')
+    end = profile.transform_datetime_parameter_timezone(today).strftime('%Y%m%d2138')
+    client = HafasClient(profile)
     journey = client.journey(
-        journey="¶HKI¶T$A=1@O=Halle (Saale) Hbf@L=8010159@a=128@$A=1@O=Leipzig Hbf (tief)@L=8098205@a=128@$202312232115$202312232138$ S5X$$1$$$$$$¶KC¶#VE#2#CF#100#CA#0#CM#0#SICT#0#AM#49#AM2#0#RT#15#¶KCC¶I1ZFIzEjRVJHIzEjSElOIzAjRUNLIzE1Njc1fDE1Njc1fDE1Njk4fDE1Njk4fDB8MHw1fDE1Njc1fDF8MHwyfDB8MHwtMjE0NzQ4MzY0OCNHQU0jMjMxMjIzMjExNSMKWiNWTiMxI1NUIzE3MDMyNDY4OTcjUEkjMCNaSSM2MDA0NSNUQSMwI0RBIzIzMTIyMyMxUyM4MDEwMTU5IzFUIzIxMTUjTFMjODAxMDM5NyNMVCMyMjU3I1BVIzgwI1JUIzEjQ0EjcyNaRSNTNVgjWkIjICAgICBTNVgjUEMjNCNGUiM4MDEwMTU5I0ZUIzIxMTUjVE8jODA5ODIwNSNUVCMyMTM4Iw==¶KRCC¶#VE#1#",
+        journey=f"¶HKI¶T$A=1@O=Halle (Saale) Hbf@L=8010159@a=128@$A=1@O=Leipzig Hbf (tief)@L=8098205@a=128@${start}${end}$ S5X$$1$$$$$$¶KC¶#VE#2#CF#100#CA#0#CM#0#SICT#0#AM#49#AM2#0#RT#15#¶KCC¶I1ZFIzEjRVJHIzEjSElOIzAjRUNLIzE1Njc1fDE1Njc1fDE1Njk4fDE1Njk4fDB8MHw1fDE1Njc1fDF8MHwyfDB8MHwtMjE0NzQ4MzY0OCNHQU0jMjMxMjIzMjExNSMKWiNWTiMxI1NUIzE3MDMyNDY4OTcjUEkjMCNaSSM2MDA0NSNUQSMwI0RBIzIzMTIyMyMxUyM4MDEwMTU5IzFUIzIxMTUjTFMjODAxMDM5NyNMVCMyMjU3I1BVIzgwI1JUIzEjQ0EjcyNaRSNTNVgjWkIjICAgICBTNVgjUEMjNCNGUiM4MDEwMTU5I0ZUIzIxMTUjVE8jODA5ODIwNSNUVCMyMTM4Iw==¶KRCC¶#VE#1#",
     )
     assert isinstance(journey, Journey)

--- a/tests/nvv/parsing/departures_test.py
+++ b/tests/nvv/parsing/departures_test.py
@@ -9,7 +9,7 @@ from tests.types import PyTestHafasResponse
 
 def test_nvv_departures_parsing():
     directory = os.path.dirname(os.path.realpath(__file__))
-    raw_hafas_json_file = open(directory + "/departures_raw.json", "r")
+    raw_hafas_json_file = open(directory + "/departures_raw.json", "r", encoding="utf8")
     hafas_response = PyTestHafasResponse(raw_hafas_json_file.read())
     raw_hafas_json_file.close()
     correct_station_board_legs = [StationBoardLeg(

--- a/tests/nvv/request/journey_test.py
+++ b/tests/nvv/request/journey_test.py
@@ -1,11 +1,17 @@
+import datetime
+
 from pyhafas import HafasClient
 from pyhafas.profile import NVVProfile
 from pyhafas.types.fptf import Journey
 
 
 def test_nvv_journey_request():
-    client = HafasClient(NVVProfile())
+    profile = NVVProfile()
+    today = datetime.datetime.now(datetime.UTC)
+    start = profile.transform_datetime_parameter_timezone(today).strftime('%Y%m%d2105')
+    end = profile.transform_datetime_parameter_timezone(today).strftime('%Y%m%d2142')
+    client = HafasClient(profile)
     journey = client.journey(
-        journey="¶HKI¶T$A=1@O=Rotenburg (Fulda) Bahnhof@L=2202508@a=128@$A=1@O=Kassel Bahnhof Wilhelmshöhe@L=2200007@a=128@$202312232105$202312232142$ RB5$$1$$$$$$¶KC¶#VE#2#CF#100#CA#0#CM#0#SICT#0#AM#49#AM2#0#RT#7#¶KRCC¶#VE#1#¶PC¶eyJncnBJZCI6IkdST1VQX1BUIn0="
+        journey=f"¶HKI¶T$A=1@O=Rotenburg (Fulda) Bahnhof@L=2202508@a=128@$A=1@O=Kassel Bahnhof Wilhelmshöhe@L=2200007@a=128@${start}${end}$ RB5$$1$$$$$$¶KC¶#VE#2#CF#100#CA#0#CM#0#SICT#0#AM#49#AM2#0#RT#7#¶KRCC¶#VE#1#¶PC¶eyJncnBJZCI6IkdST1VQX1BUIn0="
     )
     assert isinstance(journey, Journey)

--- a/tests/vsn/parsing/departures_test.py
+++ b/tests/vsn/parsing/departures_test.py
@@ -9,7 +9,7 @@ from tests.types import PyTestHafasResponse
 
 def test_vsn_departures_parsing():
     directory = os.path.dirname(os.path.realpath(__file__))
-    raw_hafas_json_file = open(directory + "/departures_raw.json", "r")
+    raw_hafas_json_file = open(directory + "/departures_raw.json", "r", encoding="utf8")
     hafas_response = PyTestHafasResponse(raw_hafas_json_file.read())
     raw_hafas_json_file.close()
     correct_station_board_legs = [StationBoardLeg(

--- a/tests/vsn/parsing/journeys_test.py
+++ b/tests/vsn/parsing/journeys_test.py
@@ -10,7 +10,7 @@ from tests.types import PyTestHafasResponse
 
 def test_vsn_journeys_parsing():
     directory = os.path.dirname(os.path.realpath(__file__))
-    raw_hafas_json_file = open(directory + "/journeys_raw.json", "r")
+    raw_hafas_json_file = open(directory + "/journeys_raw.json", "r", encoding="utf-8")
     hafas_response = PyTestHafasResponse(raw_hafas_json_file.read())
     raw_hafas_json_file.close()
     correct_journeys = [

--- a/tests/vvv/parsing/departures_test.py
+++ b/tests/vvv/parsing/departures_test.py
@@ -9,7 +9,7 @@ from tests.types import PyTestHafasResponse
 
 def test_vvv_departures_parsing():
     directory = os.path.dirname(os.path.realpath(__file__))
-    raw_hafas_json_file = open(directory + "/departures_raw.json", "r")
+    raw_hafas_json_file = open(directory + "/departures_raw.json", "r", encoding="utf8")
     hafas_response = PyTestHafasResponse(raw_hafas_json_file.read())
     raw_hafas_json_file.close()
     correct_station_board_legs = [StationBoardLeg(

--- a/tests/vvv/request/journey_test.py
+++ b/tests/vvv/request/journey_test.py
@@ -1,10 +1,17 @@
+import datetime
+
 from pyhafas import HafasClient
 from pyhafas.profile import VVVProfile
 from pyhafas.types.fptf import Journey
 
 
 def test_vvv_journey_request():
-    client = HafasClient(VVVProfile())
+    profile = VVVProfile()
+    today = datetime.datetime.now(datetime.UTC)
+    start = profile.transform_datetime_parameter_timezone(today).strftime('%Y%m%d0129')
+    end = profile.transform_datetime_parameter_timezone(today).strftime('%Y%m%d0138')
+    client = HafasClient(profile)
     journey = client.journey(
-        journey='¶HKI¶G@F$A=2@O=Adlergasse, 6850 Dornbirn@X=9733124@Y=47401432@b=980000657@a=128@$A=1@O=Dornbirn Bäumlegasse@L=480150302@a=128@$202311010129$202311010138')
+        journey=f"¶HKI¶G@F$A=2@O=Adlergasse, 6850 Dornbirn@X=9733124@Y=47401432@b=980000657@a=128@$A=1@O=Dornbirn Bäumlegasse@L=480150302@a=128@${start}${end}"
+    )
     assert isinstance(journey, Journey)


### PR DESCRIPTION
Several tests failed due to the date/time in the `journey()` request being out of the timetable period. I fixed that by actually using the current date. I assume this could still fail on public holidays or weekends with a different timetables.

Some others failed because I was running tests on a Windows machine which is using a different encoding when opening files which broke German umlauts. Passing the correct encoding to `open()` fixes that.

The `nasa/requests/journeys_test.py` still fails with the following error: `location missing or invalid`. After double checking the station IDs they seem to be valid and one can still request journeys at https://reiseauskunft.insa.de/ and https://www.insa.de/fahrplanauskunft. No idea why.