### PR TITLE
implement nearby request

### DIFF
--- a/pyhafas/client.py
+++ b/pyhafas/client.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Optional, Union
 
 from pyhafas.profile import ProfileInterface
 from pyhafas.types.fptf import Journey, Leg, Station, StationBoardLeg
+from pyhafas.types.nearby import LatLng
 from pyhafas.types.station_board_request import StationBoardRequestType
 
 
@@ -242,13 +243,41 @@ class HafasClient:
 
         return self.profile.parse_trip_request(res)
 
-    def stop(self, stop):
+    def nearby(self,
+               location: LatLng,
+               max_walking_distance: int = -1,
+               min_walking_distance: int = 0,
+               products: dict[str, bool] = {},
+               get_pois: bool = False,
+               get_stops: bool = True,
+               max_locations: int = -1
+               ) -> List[Station]:
         """
-        Not implemented yet.
-        """
-        raise NotImplementedError
+        Returns stations close to a given latitude/longitude location
 
-    def nearby(self, location):
+        Distance to stations calculated by HaFAS. The list is ordered by closest to furthest station
+
+        :param location: LatLng object containing latitude and longitude
+        :param max_walking_distance: Maximum walking distance in meters
+        :param min_walking_distance: Minimum walking distance in meters
+        :param products: Dictionary of product names to products
+        :param get_pois: If true, returns pois
+        :param get_stops: If true, returns stops instead of locations
+        :param max_locations: Maximum number of locations to return
+        """
+        body = self.profile.format_nearby_request(
+            location,
+            max_walking_distance,
+            min_walking_distance,
+            products,
+            get_pois,
+            get_stops,
+            max_locations
+        )
+        res = self.profile.request(body)
+        return self.profile.parse_nearby_response(res)
+
+    def stop(self, stop):
         """
         Not implemented yet.
         """

--- a/pyhafas/profile/base/__init__.py
+++ b/pyhafas/profile/base/__init__.py
@@ -10,6 +10,7 @@ from pyhafas.profile.base.helper.request import BaseRequestHelper
 from pyhafas.profile.base.requests.journey import BaseJourneyRequest
 from pyhafas.profile.base.requests.journeys import BaseJourneysRequest
 from pyhafas.profile.base.requests.location import BaseLocationRequest
+from pyhafas.profile.base.requests.nearby import BaseNearbyRequest
 from pyhafas.profile.base.requests.station_board import BaseStationBoardRequest
 from pyhafas.profile.base.requests.trip import BaseTripRequest
 from pyhafas.profile.interfaces import ProfileInterface
@@ -27,6 +28,7 @@ class BaseProfile(
         BaseJourneysRequest,
         BaseStationBoardRequest,
         BaseTripRequest,
+        BaseNearbyRequest,
         ProfileInterface):
     """
     Profile for a "normal" HaFAS. Only for other profiles usage as basis.

--- a/pyhafas/profile/base/requests/nearby.py
+++ b/pyhafas/profile/base/requests/nearby.py
@@ -1,0 +1,74 @@
+from typing import List
+
+from pyhafas.profile import ProfileInterface
+from pyhafas.profile.interfaces.requests.nearby import NearbyRequestInterface
+from pyhafas.types.fptf import Station
+from pyhafas.types.hafas_response import HafasResponse
+from pyhafas.types.nearby import LatLng
+
+
+class BaseNearbyRequest(NearbyRequestInterface):
+    def format_nearby_request(
+            self: ProfileInterface,
+            location: LatLng,
+            max_walking_distance: int,
+            min_walking_distance: int,
+            products: dict[str, bool],
+            get_pois: bool,
+            get_stops: bool,
+            max_locations: int,
+    ) -> dict:
+        """
+        Creates the HaFAS request body for a nearby request.
+
+        :param location: LatLng object containing latitude and longitude
+        :param max_walking_distance: Maximum walking distance in meters
+        :param min_walking_distance: Minimum walking distance in meters
+        :param products: Dictionary of product names to products
+        :param get_pois: If true, returns pois
+        :param get_stops: If true, returns stops instead of locations
+        :param max_locations: Maximum number of locations to return
+        :return: Request body for HaFAS
+        """
+        return {
+            "cfg": {
+                "polyEnc": "GPA"
+            },
+            "meth": "LocGeoPos",
+            "req": {
+                "ring": {
+                    "cCrd": {
+                        "x": location.longitude_e6,
+                        "y": location.latitude_e6,
+                    },
+                    "maxDist": max_walking_distance,
+                    "minDist": min_walking_distance,
+                },
+                "locFltrL": [
+                    self.format_products_filter(products)
+                ],
+                "getPOIs": get_pois,
+                "getStops": get_stops,
+                "maxLoc": max_locations
+
+            }
+        }
+
+    def parse_nearby_response(self: ProfileInterface, data: HafasResponse) -> List[Station]:
+        stations = []
+
+        for station in data.res["locL"]:
+            try:
+                latitude: float = station['crd']['y'] / 1E6
+                longitude: float = station['crd']['x'] / 1E6
+            except KeyError:
+                latitude: float = 0
+                longitude: float = 0
+            stations.append(
+                self.parse_lid_to_station(
+                    station['lid'],
+                    station['name'],
+                    latitude,
+                    longitude))
+
+        return stations

--- a/pyhafas/profile/interfaces/__init__.py
+++ b/pyhafas/profile/interfaces/__init__.py
@@ -15,6 +15,7 @@ from pyhafas.profile.interfaces.requests.journeys import \
     JourneysRequestInterface
 from pyhafas.profile.interfaces.requests.location import \
     LocationRequestInterface
+from pyhafas.profile.interfaces.requests.nearby import NearbyRequestInterface
 from pyhafas.profile.interfaces.requests.station_board import \
     StationBoardRequestInterface
 from pyhafas.profile.interfaces.requests.trip import TripRequestInterface
@@ -32,6 +33,7 @@ class ProfileInterface(
         JourneysRequestInterface,
         StationBoardRequestInterface,
         TripRequestInterface,
+        NearbyRequestInterface,
         ABC):
     """
     The profile interface is the abstract class of a profile.

--- a/pyhafas/profile/interfaces/requests/nearby.py
+++ b/pyhafas/profile/interfaces/requests/nearby.py
@@ -1,0 +1,35 @@
+import abc
+from typing import List
+
+from pyhafas.types.fptf import Station
+from pyhafas.types.hafas_response import HafasResponse
+from pyhafas.types.nearby import LatLng
+
+
+class NearbyRequestInterface(abc.ABC):
+    @abc.abstractmethod
+    def format_nearby_request(self,
+                              location: LatLng,
+                              max_walking_distance: int,
+                              min_walking_distance: int,
+                              products: dict[str, bool],
+                              get_pois: bool,
+                              get_stops: bool,
+                              max_locations: int) -> dict:
+        """
+        Creates the HaFAS request body for a nearby request.
+
+        :param location: LatLng object containing latitude and longitude
+        :param max_walking_distance: Maximum walking distance in meters
+        :param min_walking_distance: Minimum walking distance in meters
+        :param products: Dictionary of product names to products
+        :param get_pois: If true, returns pois
+        :param get_stops: If true, returns stops instead of locations
+        :param max_locations: Maximum number of locations to return
+        :return: Request body for HaFAS
+        """
+        pass
+
+    @abc.abstractmethod
+    def parse_nearby_response(self, data: HafasResponse) -> List[Station]:
+        pass

--- a/pyhafas/types/nearby.py
+++ b/pyhafas/types/nearby.py
@@ -1,0 +1,15 @@
+class LatLng:
+    latitude: float
+    longitude: float
+
+    def __init__(self, latitude: float, longitude: float):
+        self.latitude = latitude
+        self.longitude = longitude
+
+    @property
+    def latitude_e6(self) -> int:
+        return round(self.latitude * 1E6)
+
+    @property
+    def longitude_e6(self) -> int:
+        return round(self.longitude * 1E6)

--- a/tests/db/request/nearby_test.py
+++ b/tests/db/request/nearby_test.py
@@ -1,0 +1,12 @@
+from pyhafas import HafasClient
+from pyhafas.profile import DBProfile
+from pyhafas.types.nearby import LatLng
+from tests.distance import calculate_distance_in_meters
+
+
+def test_db_nearby_request():
+    pos = LatLng(52.523765, 13.369948)
+    client = HafasClient(DBProfile())
+    stations = client.nearby(pos)
+    assert stations
+    assert calculate_distance_in_meters(pos.latitude, pos.longitude, stations[0].latitude, stations[0].longitude) < 200

--- a/tests/distance.py
+++ b/tests/distance.py
@@ -1,0 +1,24 @@
+from math import radians, sin, cos, sqrt, atan2
+
+
+def calculate_distance_in_meters(ilat1: float, ilon1: float, ilat2: float, ilon2: float) -> float:
+    # credits to https://stackoverflow.com/a/19412565/237312
+    # used to not import external libs
+
+    # Approximate radius of earth in meters
+    r = 6373000.0
+
+    lat1 = radians(ilat1)
+    lon1 = radians(ilon1)
+    lat2 = radians(ilat2)
+    lon2 = radians(ilon2)
+
+    dlon = lon2 - lon1
+    dlat = lat2 - lat1
+
+    a = sin(dlat / 2)**2 + cos(lat1) * cos(lat2) * sin(dlon / 2)**2
+    c = 2 * atan2(sqrt(a), sqrt(1 - a))
+
+    distance = r * c
+
+    return distance

--- a/tests/kvb/request/nearby_test.py
+++ b/tests/kvb/request/nearby_test.py
@@ -1,0 +1,12 @@
+from pyhafas import HafasClient
+from pyhafas.profile import KVBProfile
+from pyhafas.types.nearby import LatLng
+from tests.distance import calculate_distance_in_meters
+
+
+def test_kvb_nearby_request():
+    pos = LatLng(50.940614, 6.958120)
+    client = HafasClient(KVBProfile())
+    stations = client.nearby(pos)
+    assert stations
+    assert calculate_distance_in_meters(pos.latitude, pos.longitude, stations[0].latitude, stations[0].longitude) < 200

--- a/tests/nasa/requests/nearby_test.py
+++ b/tests/nasa/requests/nearby_test.py
@@ -1,0 +1,12 @@
+from pyhafas import HafasClient
+from pyhafas.profile import NASAProfile
+from pyhafas.types.nearby import LatLng
+from tests.distance import calculate_distance_in_meters
+
+
+def test_nasa_nearby_request():
+    pos = LatLng(52.131019, 11.622818)
+    client = HafasClient(NASAProfile())
+    stations = client.nearby(pos)
+    assert stations
+    assert calculate_distance_in_meters(pos.latitude, pos.longitude, stations[0].latitude, stations[0].longitude) < 200

--- a/tests/nvv/request/nearby_test.py
+++ b/tests/nvv/request/nearby_test.py
@@ -1,0 +1,12 @@
+from pyhafas import HafasClient
+from pyhafas.profile import NVVProfile
+from pyhafas.types.nearby import LatLng
+from tests.distance import calculate_distance_in_meters
+
+
+def test_nvv_nearby_request():
+    pos = LatLng(51.317862, 9.490816)
+    client = HafasClient(NVVProfile())
+    stations = client.nearby(pos)
+    assert stations
+    assert calculate_distance_in_meters(pos.latitude, pos.longitude, stations[0].latitude, stations[0].longitude) < 200

--- a/tests/vsn/request/nearby_test.py
+++ b/tests/vsn/request/nearby_test.py
@@ -1,0 +1,12 @@
+from pyhafas import HafasClient
+from pyhafas.profile import VSNProfile
+from pyhafas.types.nearby import LatLng
+from tests.distance import calculate_distance_in_meters
+
+
+def test_vsn_nearby_request():
+    pos = LatLng(51.536403, 9.927406)
+    client = HafasClient(VSNProfile())
+    stations = client.nearby(pos)
+    assert stations
+    assert calculate_distance_in_meters(pos.latitude, pos.longitude, stations[0].latitude, stations[0].longitude) < 200

--- a/tests/vvv/request/nearby_test.py
+++ b/tests/vvv/request/nearby_test.py
@@ -1,0 +1,12 @@
+from pyhafas import HafasClient
+from pyhafas.profile import VVVProfile
+from pyhafas.types.nearby import LatLng
+from tests.distance import calculate_distance_in_meters
+
+
+def test_vvv_nearby_request():
+    pos = LatLng(47.272502, 9.638032)
+    client = HafasClient(VVVProfile())
+    stations = client.nearby(pos)
+    assert stations
+    assert calculate_distance_in_meters(pos.latitude, pos.longitude, stations[0].latitude, stations[0].longitude) < 200


### PR DESCRIPTION
I have implemented the `nearby` request which returns a list of stations ordered from closest to furthest

Somewhat fixes the following issue or at least makes it easier to implement

* #40 

We could think about implementing a different return type for this endpoint to also include the distance. HaFas seems to return the distance in meters as well via `data.res["locL"][i]["dist"]` and according to [public-transport/hafas-client](https://github.com/public-transport/hafas-client) probably even the walking duration via `data.res["locL"][i]["dur"]` in whatever format