### PR TITLE
- Added ability to parse additional name (like RE 4) 

### DIFF
--- a/pyhafas/profile/base/helper/parse_leg.py
+++ b/pyhafas/profile/base/helper/parse_leg.py
@@ -90,6 +90,7 @@ class BaseParseLegHelper(ParseLegHelperInterface):
             return Leg(
                 id=journey['jid'],
                 name=common['prodL'][journey['prodX']]['name'],
+                additional_name=common['prodL'][journey['prodX']].get('addName', None),
                 origin=leg_origin,
                 destination=leg_destination,
                 cancelled=bool(arrival.get('aCncl', False)),

--- a/pyhafas/profile/base/requests/station_board.py
+++ b/pyhafas/profile/base/requests/station_board.py
@@ -97,6 +97,7 @@ class BaseStationBoardRequest(StationBoardRequestInterface):
                         date) - self.parse_datetime(
                         raw_leg['stbStop'][departure_arrival_prefix + 'TimeS'],
                         date) if raw_leg['stbStop'].get(departure_arrival_prefix + 'TimeR') is not None else None,
-                    cancelled=bool(raw_leg['stbStop'].get(departure_arrival_prefix + 'Cncl', False))
-                ))
+                    cancelled=bool(raw_leg['stbStop'].get(departure_arrival_prefix + 'Cncl', False)),
+                    additional_name=data.common['prodL'][raw_leg['prodX']].get('addName', None),)
+                )
             return legs

--- a/pyhafas/types/fptf.py
+++ b/pyhafas/types/fptf.py
@@ -224,6 +224,7 @@ class Leg(FPTFObject):
             arrival: datetime.datetime,
             mode: Mode = Mode.TRAIN,
             name: Optional[str] = None,
+            additional_name: Optional[str] = None,
             cancelled: bool = False,
             distance: Optional[int] = None,
             departure_delay: Optional[datetime.timedelta] = None,
@@ -242,7 +243,8 @@ class Leg(FPTFObject):
         :param departure: Planned date and Time of the departure
         :param arrival: Planned date and Time of the arrival
         :param mode: (optional) Type of transport vehicle - Must be a part of the FPTF `Mode` enum. Defaults to `Mode.TRAIN`
-        :param name: (optional) Name of the trip (e.g. ICE 123). Defaults to None
+        :param name: (optional) Name of the trip (e.g. RE 10354). Defaults to None
+        :param additional_name: (optional) Additional name of the trip (e.g. RE 4). Defaults to None
         :param cancelled: (optional) Whether the trip is cancelled. Defaults to False
         :param distance: (optional) Distance of the walk trip in meters. Defaults to None
         :param departure_delay: (optional) Delay at the departure station. Defaults to None
@@ -262,6 +264,7 @@ class Leg(FPTFObject):
         # Optional Variables
         self.mode: Mode = mode
         self.name: Optional[str] = name
+        self.additionalName: Optional[str] = additional_name
         self.cancelled: bool = cancelled
         self.distance: Optional[int] = distance
         self.departureDelay: Optional[datetime.timedelta] = departure_delay
@@ -344,7 +347,9 @@ class StationBoardLeg(FPTFObject):
             date_time: datetime.datetime,
             cancelled: bool,
             delay: Optional[datetime.timedelta] = None,
-            platform: Optional[str] = None
+            platform: Optional[str] = None,
+            additional_name: Optional[str] = None,
+
     ):
         """
         `StationBoardLeg` object
@@ -357,6 +362,7 @@ class StationBoardLeg(FPTFObject):
         :param cancelled: Whether the stop or trip cancelled
         :param delay: (optional) Delay at the departure station. Defaults to `None`
         :param platform: (optional) Real-time platform at the station. Defaults to `None`
+        :param additional_name: (optional) Additional name if available (e.g. RE 4)
         """
         self.id: str = id
         self.name: str = name
@@ -366,3 +372,4 @@ class StationBoardLeg(FPTFObject):
         self.cancelled: bool = cancelled
         self.delay: Optional[datetime.timedelta] = delay
         self.platform: Optional[str] = platform
+        self.additionalName: str = additional_name

--- a/tests/db/request/trip_test.py
+++ b/tests/db/request/trip_test.py
@@ -4,11 +4,14 @@ from pyhafas import HafasClient
 from pyhafas.profile import DBProfile
 
 
-def test_db_departures_request():
+def test_db_trip_request():
     client = HafasClient(DBProfile())
     departures = client.departures(
         station="8000404",
         date=datetime.datetime.now(),
         max_trips=10
     )
-    assert len(departures) <= 10
+
+    trips = [client.trip(departure.id) for departure in departures]
+
+    assert len(trips) <= 10


### PR DESCRIPTION
So far the train number was only passed like RE 10453 which is not ideal to display to users. The response can contain also an additional name like RE 4. This is now being parsed. If it is not available in the response its set to None

I also added a test to check client.trip()